### PR TITLE
Support build_graph for replica and scannet

### DIFF
--- a/application/create_graph.py
+++ b/application/create_graph.py
@@ -22,18 +22,16 @@ def main(params: DictConfig):
     hovsg.save_masked_pcds(path=save_dir, state="both")
     hovsg.save_full_pcd(path=save_dir)
     hovsg.save_full_pcd_feats(path=save_dir)
-    
+
     # for debugging: load preconstructed map as follows
     # hovsg.load_full_pcd(path=save_dir)
     # hovsg.load_full_pcd_feats(path=save_dir)
     # hovsg.load_masked_pcds(path=save_dir)
-    
+
     # create graph, only if dataset is not Replia or ScanNet
     print(params.main.dataset)
-    if params.main.dataset != "replica" and params.main.dataset != "scannet" and params.pipeline.create_graph:
-        hovsg.build_graph(save_path=save_dir)
-    else:
-        print("Skipping hierarchical scene graph creation for Replica and ScanNet datasets.")
+    hovsg.build_graph(save_path=save_dir)
+
 
 if __name__ == "__main__":
     main()

--- a/config/create_graph_config.yaml
+++ b/config/create_graph_config.yaml
@@ -7,7 +7,7 @@ main:
 models:
   clip:
     type:  ViT-H-14 # ViT-L/14@336px # ViT-H-14
-    checkpoint: checkpoints/laion2b_s32b_b79k.bin 
+    checkpoint: checkpoints/laion2b_s32b_b79k.bin
     # checkpoint: checkpoints/ovseg_clipl14_9a1909.pth checkpoints/laion2b_s32b_b79k.bin
   sam:
     checkpoint: checkpoints/sam_vit_h_4b8939.pth
@@ -32,7 +32,7 @@ pipeline:
   min_pcd_points: 100
   depth_weighting: false
   grid_resolution: 0.05
-  merge_type: sequential # hierarchical, sequential
+  merge_type: hierarchical # hierarchical, sequential
   save_intermediate_results: false
   obj_labels: HM3DSEM_LABELS
   merge_objects_graph: false

--- a/hovsg/graph/navigation_graph.py
+++ b/hovsg/graph/navigation_graph.py
@@ -841,6 +841,10 @@ class NavigationGraph:
             cv2.circle(top_down, tuple(np.int32(pos_2d[[0, 2]])), 2, (255, 0, 0), -1)
             cv2.imwrite(os.path.join(floor_dir, "top_down_rgb_poses.png"), top_down)
 
+        if len(tar_poses) == 0:
+            self.has_stairs = False
+            return nx.Graph()
+
         min_height = np.min([pos[1] for pos in tar_poses])
         # cv2.imshow("stairs poses", top_down)
         # cv2.waitKey()


### PR DESCRIPTION
With these changes I was able to run build_graph for the replica dataset. They bypass some assumptions about floors and stairs